### PR TITLE
Corrected grammar in comment in hooks.md

### DIFF
--- a/components/modal/demo/hooks.md
+++ b/components/modal/demo/hooks.md
@@ -66,7 +66,7 @@ const App: React.FC = () => {
           Error
         </Button>
       </Space>
-      {/* `contextHolder` should always under the context you want to access */}
+      {/* `contextHolder` should always be placed under the context you want to access */}
       {contextHolder}
 
       {/* Can not access this context since `contextHolder` is not in it */}


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] New feature
- [ ] Bug fix
- [x] Site / documentation update
- [x] Demo update
- [ ] Component style update
- [ ] TypeScript definition update
- [ ] Bundle size optimization
- [ ] Performance optimization
- [ ] Enhancement feature
- [ ] Internationalization
- [ ] Refactoring
- [ ] Code style optimization
- [ ] Test Case
- [ ] Branch merge
- [ ] Other (about what?)

### 🔗 Related issue link

N/A

### 💡 Background and solution

The demo in the documentation for the `useModal` hook has a grammar mistake in a comment.

### 📝 Changelog

This is changing a comment, so it's impossible for this to create new bugs for the user.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English |       X   |
| 🇨🇳 Chinese |           |

### ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] TypeScript definition is updated/provided or not needed
- [x] Changelog is provided or not needed
